### PR TITLE
Update sync DTOs

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/model/MangaSyncDto.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/model/MangaSyncDto.kt
@@ -5,6 +5,7 @@ import androidx.core.database.getStringOrNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.koitharu.kotatsu.core.util.ext.buildContentValues
+import org.koitharu.kotatsu.core.util.ext.getBoolean
 
 @Serializable
 data class MangaSyncDto(
@@ -21,6 +22,7 @@ data class MangaSyncDto(
 	@SerialName("state") val state: String?,
 	@SerialName("author") val author: String?,
 	@SerialName("source") val source: String,
+	@SerialName("nsfw") val nsfw: Boolean,
 ) {
 
 	constructor(cursor: Cursor, tags: Set<MangaTagSyncDto>) : this(
@@ -37,6 +39,7 @@ data class MangaSyncDto(
 		state = cursor.getStringOrNull(cursor.getColumnIndexOrThrow("state")),
 		author = cursor.getStringOrNull(cursor.getColumnIndexOrThrow("author")),
 		source = cursor.getString(cursor.getColumnIndexOrThrow("source")),
+		nsfw = cursor.getBoolean(cursor.getColumnIndexOrThrow("nsfw")),
 	)
 
 	fun toContentValues() = buildContentValues(12) {
@@ -52,6 +55,6 @@ data class MangaSyncDto(
 		put("state", state)
 		put("author", author)
 		put("source", source)
-		put("nsfw", false)
+		put("nsfw", nsfw)
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/model/MangaSyncDto.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/model/MangaSyncDto.kt
@@ -52,5 +52,6 @@ data class MangaSyncDto(
 		put("state", state)
 		put("author", author)
 		put("source", source)
+		put("nsfw", false)
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/model/MangaSyncDto.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/model/MangaSyncDto.kt
@@ -22,7 +22,7 @@ data class MangaSyncDto(
 	@SerialName("state") val state: String?,
 	@SerialName("author") val author: String?,
 	@SerialName("source") val source: String,
-	@SerialName("nsfw") val nsfw: Boolean,
+	@SerialName("nsfw") val nsfw: Boolean = false,
 ) {
 
 	constructor(cursor: Cursor, tags: Set<MangaTagSyncDto>) : this(

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/model/MangaTagSyncDto.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/model/MangaTagSyncDto.kt
@@ -25,5 +25,6 @@ data class MangaTagSyncDto(
 		put("title", title)
 		put("key", key)
 		put("source", source)
+		put("pinned", false)
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/model/MangaTagSyncDto.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/model/MangaTagSyncDto.kt
@@ -12,7 +12,7 @@ data class MangaTagSyncDto(
 	@SerialName("title") val title: String,
 	@SerialName("key") val key: String,
 	@SerialName("source") val source: String,
-	@SerialName("pinned") val pinned: Boolean,
+	@SerialName("pinned") val pinned: Boolean = false,
 ) {
 
 	constructor(cursor: Cursor) : this(

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/model/MangaTagSyncDto.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/model/MangaTagSyncDto.kt
@@ -4,6 +4,7 @@ import android.database.Cursor
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.koitharu.kotatsu.core.util.ext.buildContentValues
+import org.koitharu.kotatsu.core.util.ext.getBoolean
 
 @Serializable
 data class MangaTagSyncDto(
@@ -11,6 +12,7 @@ data class MangaTagSyncDto(
 	@SerialName("title") val title: String,
 	@SerialName("key") val key: String,
 	@SerialName("source") val source: String,
+	@SerialName("pinned") val pinned: Boolean,
 ) {
 
 	constructor(cursor: Cursor) : this(
@@ -18,6 +20,7 @@ data class MangaTagSyncDto(
 		title = cursor.getString(cursor.getColumnIndexOrThrow("title")),
 		key = cursor.getString(cursor.getColumnIndexOrThrow("key")),
 		source = cursor.getString(cursor.getColumnIndexOrThrow("source")),
+		pinned = cursor.getBoolean(cursor.getColumnIndexOrThrow("pinned")),
 	)
 
 	fun toContentValues() = buildContentValues(4) {
@@ -25,6 +28,6 @@ data class MangaTagSyncDto(
 		put("title", title)
 		put("key", key)
 		put("source", source)
-		put("pinned", false)
+		put("pinned", pinned)
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/SyncHelper.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/SyncHelper.kt
@@ -58,6 +58,10 @@ class SyncHelper @AssistedInject constructor(
 	private val settings: SyncSettings,
 ) {
 
+	private val json = Json {
+		encodeDefaults = true
+	}
+
 	private val authorityHistory = context.getString(R.string.sync_authority_history)
 	private val authorityFavourites = context.getString(R.string.sync_authority_favourites)
 	private val mediaTypeJson = "application/json".toMediaType()
@@ -73,7 +77,7 @@ class SyncHelper @AssistedInject constructor(
 
 	@WorkerThread
 	fun syncFavourites(stats: SyncStats) {
-		val payload = Json.encodeToString(
+		val payload = json.encodeToString(
 			SyncDto(
 				history = null,
 				favourites = getFavourites(),
@@ -103,7 +107,7 @@ class SyncHelper @AssistedInject constructor(
 	@Blocking
 	@WorkerThread
 	fun syncHistory(stats: SyncStats) {
-		val payload = Json.encodeToString(
+		val payload = json.encodeToString(
 			SyncDto(
 				history = getHistory(),
 				favourites = null,


### PR DESCRIPTION
This updates the sync DTOs to include the missing fields, since the current implementation just throws an error when trying to sync (see #27). The changes seem to work fine for me, sync from one device to another works, even if I have to manually sync sometimes after opening the app (maybe that's something to improve in the future, along with better links for account management in the app and a built-in password reset option).

The change is also backwards compatible with the old sync server by providing defaults in case the server doesn't support the new fields.

As for the sync server, I have also created [a fork](https://git.cringe-studios.com/mr/kotatsu-syncserver-improved) ([GH mirror](https://github.com/MrLetsplay2003/kotatsu-syncserver)) with an updated database schema. As there doesn't seem to be a Kotatsu-Redo fork of the sync server, I can't really contribute the changes right now. When there is one, I will open a corresponding PR there.

Also, since all(?) of the officially provided sync server instances are down, I was thinking about hosting my own public one (running my fork of the sync server). If you want, I could also add it to the app as an option and maybe remove the old non-running servers from the list.