### PR TITLE
Improve sync UI

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -159,6 +159,7 @@
 				<data android:scheme="kotatsu" />
 				<data android:host="about" />
 				<data android:host="sync-settings" />
+				<data android:host="reset-password" />
 			</intent-filter>
 		</activity>
 		<activity
@@ -220,6 +221,10 @@
 			android:label="@string/edit" />
 		<activity
 			android:name="org.koitharu.kotatsu.sync.ui.SyncAuthActivity"
+			android:exported="true"
+			android:label="@string/sync" />
+		<activity
+			android:name="org.koitharu.kotatsu.sync.ui.SyncAuthResetActivity"
 			android:exported="true"
 			android:label="@string/sync" />
 		<activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -159,7 +159,6 @@
 				<data android:scheme="kotatsu" />
 				<data android:host="about" />
 				<data android:host="sync-settings" />
-				<data android:host="reset-password" />
 			</intent-filter>
 		</activity>
 		<activity
@@ -226,7 +225,19 @@
 		<activity
 			android:name="org.koitharu.kotatsu.sync.ui.SyncAuthResetActivity"
 			android:exported="true"
-			android:label="@string/sync" />
+			android:label="@string/sync"
+			android:launchMode="singleTop">
+
+			<intent-filter>
+				<action android:name="android.intent.action.VIEW" />
+
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+
+				<data android:scheme="kotatsu" />
+				<data android:host="reset-password" />
+			</intent-filter>
+		</activity>
 		<activity
 			android:name="org.koitharu.kotatsu.reader.ui.colorfilter.ColorFilterConfigActivity"
 			android:label="@string/color_correction" />

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/prefs/AppSettings.kt
@@ -749,8 +749,6 @@ class AppSettings @Inject constructor(@ApplicationContext context: Context) {
 		const val KEY_EXIT_CONFIRM = "exit_confirm"
 		const val KEY_INCOGNITO_MODE = "incognito"
 		const val KEY_READER_MULTITASK = "reader_multitask"
-		const val KEY_SYNC = "sync"
-		const val KEY_SYNC_SETTINGS = "sync_settings"
 		const val KEY_READER_BAR = "reader_bar"
 		const val KEY_READER_BAR_TRANSPARENT = "reader_bar_transparent"
 		const val KEY_READER_CHAPTER_TOAST = "reader_chapter_toast"

--- a/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/welcome/WelcomeSheet.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/main/ui/welcome/WelcomeSheet.kt
@@ -1,6 +1,5 @@
 package org.koitharu.kotatsu.main.ui.welcome
 
-import android.accounts.AccountManager
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -27,13 +26,18 @@ import org.koitharu.kotatsu.core.util.ext.tryLaunch
 import org.koitharu.kotatsu.databinding.SheetWelcomeBinding
 import org.koitharu.kotatsu.filter.ui.model.FilterProperty
 import org.koitharu.kotatsu.parsers.model.ContentType
+import org.koitharu.kotatsu.sync.domain.SyncController
 import java.util.Locale
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class WelcomeSheet : BaseAdaptiveSheet<SheetWelcomeBinding>(), ChipsView.OnChipClickListener, View.OnClickListener,
 	ActivityResultCallback<Uri?> {
 
 	private val viewModel by viewModels<WelcomeViewModel>()
+
+	@Inject
+	lateinit var syncController: SyncController
 
 	private val backupSelectCall = registerForActivityResult(
 		ActivityResultContracts.OpenDocument(),
@@ -83,9 +87,7 @@ class WelcomeSheet : BaseAdaptiveSheet<SheetWelcomeBinding>(), ChipsView.OnChipC
 			}
 
 			R.id.chip_sync -> {
-				val am = AccountManager.get(v.context)
-				val accountType = getString(R.string.account_type_sync)
-				am.addAccount(accountType, accountType, null, null, requireActivity(), null, null)
+				syncController.addAccount(requireActivity()) {}
 			}
 
             R.id.chip_directories -> {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/ServicesSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/ServicesSettingsFragment.kt
@@ -62,7 +62,6 @@ class ServicesSettingsFragment : BasePreferenceFragment(R.string.services),
 		bindScrobblerSummary(AppSettings.KEY_ANILIST, ScrobblerService.ANILIST)
 		bindScrobblerSummary(AppSettings.KEY_MAL, ScrobblerService.MAL)
 		bindScrobblerSummary(AppSettings.KEY_KITSU, ScrobblerService.KITSU)
-		bindSyncSummary()
 	}
 
 	override fun onSharedPreferenceChanged(prefs: SharedPreferences?, key: String?) {
@@ -92,20 +91,6 @@ class ServicesSettingsFragment : BasePreferenceFragment(R.string.services),
 
 			AppSettings.KEY_KITSU -> {
 				handleScrobblerClick(ScrobblerService.KITSU)
-				true
-			}
-
-			AppSettings.KEY_SYNC -> {
-				val am = AccountManager.get(requireContext())
-				val accountType = getString(R.string.account_type_sync)
-				val account = am.getAccountsByType(accountType).firstOrNull()
-				if (account == null) {
-					am.addAccount(accountType, accountType, null, null, requireActivity(), null, null)
-				} else {
-					if (!router.openSystemSyncSettings(account)) {
-						Snackbar.make(listView, R.string.operation_not_supported, Snackbar.LENGTH_SHORT).show()
-					}
-				}
 				true
 			}
 
@@ -146,23 +131,6 @@ class ServicesSettingsFragment : BasePreferenceFragment(R.string.services),
 			confirmScrobblerAuth(scrobblerService)
 		} else {
 			router.openScrobblerSettings(scrobblerService)
-		}
-	}
-
-	private fun bindSyncSummary() {
-		viewLifecycleScope.launch {
-			val account = withContext(Dispatchers.Default) {
-				val type = getString(R.string.account_type_sync)
-				AccountManager.get(requireContext()).getAccountsByType(type).firstOrNull()
-			}
-			findPreference<Preference>(AppSettings.KEY_SYNC)?.run {
-				summary = when {
-					account == null -> getString(R.string.sync_title)
-					syncController.isEnabled(account) -> account.name
-					else -> getString(R.string.disabled)
-				}
-			}
-			findPreference<Preference>(AppSettings.KEY_SYNC_SETTINGS)?.isEnabled = account != null
 		}
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/SettingsActivity.kt
@@ -162,7 +162,6 @@ class SettingsActivity :
 				when (intent.data?.host) {
 					HOST_ABOUT -> AboutSettingsFragment()
 					HOST_SYNC_SETTINGS -> SyncSettingsFragment()
-					HOST_RESET_PASSWORD -> SyncSettingsFragment()
 					else -> null
 				}
 			}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/SettingsActivity.kt
@@ -162,6 +162,7 @@ class SettingsActivity :
 				when (intent.data?.host) {
 					HOST_ABOUT -> AboutSettingsFragment()
 					HOST_SYNC_SETTINGS -> SyncSettingsFragment()
+					HOST_RESET_PASSWORD -> SyncSettingsFragment()
 					else -> null
 				}
 			}
@@ -182,9 +183,9 @@ class SettingsActivity :
 	}
 
 	companion object {
-
-		private const val HOST_ABOUT = "about"
-		private const val HOST_SYNC_SETTINGS = "sync-settings"
+		const val HOST_ABOUT = "about"
+		const val HOST_SYNC_SETTINGS = "sync-settings"
+		const val HOST_RESET_PASSWORD = "reset-password"
 		const val ARG_PREF_KEY = "pref_key"
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/SettingsActivity.kt
@@ -182,9 +182,8 @@ class SettingsActivity :
 	}
 
 	companion object {
-		const val HOST_ABOUT = "about"
-		const val HOST_SYNC_SETTINGS = "sync-settings"
-		const val HOST_RESET_PASSWORD = "reset-password"
+		private const val HOST_ABOUT = "about"
+		private const val HOST_SYNC_SETTINGS = "sync-settings"
 		const val ARG_PREF_KEY = "pref_key"
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/SyncSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/SyncSettingsFragment.kt
@@ -1,9 +1,7 @@
 package org.koitharu.kotatsu.settings
 
 import android.accounts.AccountManager
-import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.fragment.app.FragmentResultListener
 import androidx.preference.Preference
@@ -31,19 +29,6 @@ class SyncSettingsFragment : BasePreferenceFragment(R.string.sync_settings), Fra
 	lateinit var syncController: SyncController
 
 	override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
-		Log.d("AMOGUS", requireActivity().intent.data.toString())
-		val intent = activity?.intent
-		when(intent?.action) {
-			Intent.ACTION_VIEW -> {
-				when (intent.data?.host) {
-					SettingsActivity.HOST_RESET_PASSWORD -> {
-						Log.d("AMOGUS", intent.data?.query.toString())
-					}
-					else -> null
-				}
-			}
-		}
-
 		addPreferencesFromResource(R.xml.pref_sync)
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/SyncSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/SyncSettingsFragment.kt
@@ -2,7 +2,9 @@ package org.koitharu.kotatsu.settings
 
 import android.accounts.AccountManager
 import android.accounts.AccountManagerFuture
+import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.fragment.app.FragmentResultListener
 import androidx.preference.Preference
@@ -30,6 +32,19 @@ class SyncSettingsFragment : BasePreferenceFragment(R.string.sync_settings), Fra
 	lateinit var syncController: SyncController
 
 	override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+		Log.d("AMOGUS", requireActivity().intent.data.toString())
+		val intent = activity?.intent
+		when(intent?.action) {
+			Intent.ACTION_VIEW -> {
+				when (intent.data?.host) {
+					SettingsActivity.HOST_RESET_PASSWORD -> {
+						Log.d("AMOGUS", intent.data?.query.toString())
+					}
+					else -> null
+				}
+			}
+		}
+
 		addPreferencesFromResource(R.xml.pref_sync)
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/settings/SyncSettingsFragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/settings/SyncSettingsFragment.kt
@@ -1,13 +1,22 @@
 package org.koitharu.kotatsu.settings
 
+import android.accounts.AccountManager
+import android.accounts.AccountManagerFuture
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.FragmentResultListener
 import androidx.preference.Preference
+import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koitharu.kotatsu.R
+import org.koitharu.kotatsu.core.nav.router
 import org.koitharu.kotatsu.core.ui.BasePreferenceFragment
+import org.koitharu.kotatsu.core.util.ext.viewLifecycleScope
 import org.koitharu.kotatsu.sync.data.SyncSettings
+import org.koitharu.kotatsu.sync.domain.SyncController
 import org.koitharu.kotatsu.sync.ui.SyncHostDialogFragment
 import javax.inject.Inject
 
@@ -17,14 +26,22 @@ class SyncSettingsFragment : BasePreferenceFragment(R.string.sync_settings), Fra
 	@Inject
 	lateinit var syncSettings: SyncSettings
 
+	@Inject
+	lateinit var syncController: SyncController
+
 	override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
 		addPreferencesFromResource(R.xml.pref_sync)
-		bindHostSummary()
 	}
 
 	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 		super.onViewCreated(view, savedInstanceState)
 		childFragmentManager.setFragmentResultListener(SyncHostDialogFragment.REQUEST_KEY, viewLifecycleOwner, this)
+		bindSummaries()
+	}
+
+	override fun onResume() {
+		super.onResume()
+		bindSummaries()
 	}
 
 	override fun onPreferenceTreeClick(preference: Preference): Boolean {
@@ -34,16 +51,84 @@ class SyncSettingsFragment : BasePreferenceFragment(R.string.sync_settings), Fra
 				true
 			}
 
+			SyncSettings.KEY_SYNC -> {
+				val am = AccountManager.get(requireContext())
+				val accountType = getString(R.string.account_type_sync)
+				val account = am.getAccountsByType(accountType).firstOrNull()
+				if (account == null) {
+					am.addAccount(accountType, accountType, null, null, requireActivity(), ::onAccountUpdated, null)
+				} else {
+					if (!router.openSystemSyncSettings(account)) {
+						Snackbar.make(listView, R.string.operation_not_supported, Snackbar.LENGTH_SHORT).show()
+					}
+				}
+				true
+			}
+
+			SyncSettings.KEY_LOGOUT -> {
+				val am = AccountManager.get(requireContext())
+				val accountType = getString(R.string.account_type_sync)
+				val account = am.getAccountsByType(accountType).firstOrNull()
+				if(account != null) {
+					am.removeAccount(account, requireActivity(), ::onAccountUpdated, null)
+				}
+				true
+			}
+
 			else -> super.onPreferenceTreeClick(preference)
 		}
 	}
 
 	override fun onFragmentResult(requestKey: String, result: Bundle) {
-		bindHostSummary()
+		bindSummaries()
 	}
 
 	private fun bindHostSummary() {
 		val preference = findPreference<Preference>(SyncSettings.KEY_SYNC_URL) ?: return
 		preference.summary = syncSettings.syncUrl
+	}
+
+	private fun onAccountUpdated(future: AccountManagerFuture<Bundle>) {
+		val am = AccountManager.get(requireContext())
+		val accountType = getString(R.string.account_type_sync)
+		val account = am.getAccountsByType(accountType).firstOrNull()
+
+		if(account != null) {
+			syncController.setEnabled(account, syncFavorites = true, syncHistory = true)
+			viewLifecycleScope.launch {
+				syncController.requestFullSync()
+			}
+		}
+
+		bindSummaries()
+	}
+
+	private fun bindSummaries() {
+		bindHostSummary()
+		bindSyncSummary()
+	}
+
+	private fun bindSyncSummary() {
+		viewLifecycleScope.launch {
+			val account = withContext(Dispatchers.Default) {
+				val type = getString(R.string.account_type_sync)
+				AccountManager.get(requireContext()).getAccountsByType(type).firstOrNull()
+			}
+			findPreference<Preference>(SyncSettings.KEY_SYNC)?.run {
+				summary = when {
+					account == null -> getString(R.string.sync_login)
+					syncController.isEnabled(account) -> {
+						val enabledSync = ArrayList<String>()
+						if(syncController.isFavouritesEnabled(account)) enabledSync.add(getString(R.string.favourites))
+						if(syncController.isHistoryEnabled(account)) enabledSync.add(getString(R.string.history))
+
+						account.name + enabledSync.joinToString(", ", " (", ")")
+					}
+					else -> getString(R.string.disabled)
+				}
+			}
+			findPreference<Preference>(SyncSettings.KEY_SYNC_URL)?.isEnabled = account != null
+			findPreference<Preference>(SyncSettings.KEY_LOGOUT)?.isEnabled = account != null
+		}
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/SyncAuthApi.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/SyncAuthApi.kt
@@ -35,4 +35,36 @@ class SyncAuthApi @Inject constructor(
 			throw SyncApiException(message, code)
 		}
 	}
+
+	suspend fun forgotPassword(syncURL: String, email: String) {
+		val body = JSONObject(
+			mapOf("email" to email),
+		).toRequestBody()
+		val request = Request.Builder()
+			.url("$syncURL/forgot-password")
+			.post(body)
+			.build()
+		val response = okHttpClient.newCall(request).await()
+		if (!response.isSuccessful) {
+			val code = response.code
+			val message = response.parseRaw().removeSurrounding('"')
+			throw SyncApiException(message, code)
+		}
+	}
+
+	suspend fun resetPassword(syncURL: String, resetToken: String, password: String) {
+		val body = JSONObject(
+			mapOf("reset_token" to resetToken, "password" to password),
+		).toRequestBody()
+		val request = Request.Builder()
+			.url("$syncURL/reset-password")
+			.post(body)
+			.build()
+		val response = okHttpClient.newCall(request).await()
+		if (!response.isSuccessful) {
+			val code = response.code
+			val message = response.parseRaw().removeSurrounding('"')
+			throw SyncApiException(message, code)
+		}
+	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/SyncSettings.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/data/SyncSettings.kt
@@ -46,6 +46,8 @@ class SyncSettings(
 			"http://$this"
 		}
 
+		const val KEY_SYNC = "sync"
 		const val KEY_SYNC_URL = "host"
+		const val KEY_LOGOUT = "logout"
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/SyncController.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/SyncController.kt
@@ -2,6 +2,8 @@ package org.koitharu.kotatsu.sync.domain
 
 import android.accounts.Account
 import android.accounts.AccountManager
+import android.accounts.AccountManagerCallback
+import android.app.Activity
 import android.content.ContentResolver
 import android.content.ContentResolver.SYNC_OBSERVER_TYPE_ACTIVE
 import android.content.Context
@@ -9,7 +11,9 @@ import android.os.Bundle
 import androidx.room.InvalidationTracker
 import androidx.room.withTransaction
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
@@ -49,6 +53,31 @@ class SyncController @Inject constructor(
 		if (favourites || history) {
 			requestSync(favourites, history)
 		}
+	}
+
+	fun addAccount(activity: Activity, callback: (account: Account?) -> Unit) {
+		am.addAccount(accountType, accountType, null, null, activity, { _ -> onAccountUpdated(callback) }, null)
+	}
+
+	fun removeAccount(activity: Activity, account: Account, callback: (account: Account?) -> Unit) {
+		val handler = AccountManagerCallback<Bundle> { _ -> onAccountUpdated(callback) }
+		am.removeAccount(account, activity, handler, null)
+	}
+
+	private fun onAccountUpdated(callback: (account: Account?) -> Unit) {
+		val account = am.getAccountsByType(accountType).firstOrNull()
+
+		if(account != null) {
+			setEnabled(account, syncFavorites = true, syncHistory = true)
+			val job = SupervisorJob()
+			val dispatcher = Dispatchers.IO
+			val scope = CoroutineScope(job + dispatcher)
+			scope.launch {
+				requestFullSync()
+			}
+		}
+
+		callback(account)
 	}
 
 	fun setEnabled(account: Account, syncFavorites: Boolean, syncHistory: Boolean) {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/SyncController.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/domain/SyncController.kt
@@ -51,6 +51,11 @@ class SyncController @Inject constructor(
 		}
 	}
 
+	fun setEnabled(account: Account, syncFavorites: Boolean, syncHistory: Boolean) {
+		ContentResolver.setSyncAutomatically(account, authorityFavourites, syncFavorites)
+		ContentResolver.setSyncAutomatically(account, authorityHistory, syncHistory)
+	}
+
 	fun isEnabled(account: Account): Boolean {
 		return ContentResolver.getMasterSyncAutomatically() && (ContentResolver.getSyncAutomatically(
 			account,
@@ -59,6 +64,20 @@ class SyncController @Inject constructor(
 			account,
 			authorityHistory,
 		))
+	}
+
+	fun isFavouritesEnabled(account: Account): Boolean {
+		return ContentResolver.getMasterSyncAutomatically() && ContentResolver.getSyncAutomatically(
+			account,
+			authorityFavourites,
+		)
+	}
+
+	fun isHistoryEnabled(account: Account): Boolean {
+		return ContentResolver.getMasterSyncAutomatically() && ContentResolver.getSyncAutomatically(
+			account,
+			authorityHistory,
+		)
 	}
 
 	fun getLastSync(account: Account, authority: String): Long {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthActivity.kt
@@ -60,12 +60,14 @@ class SyncAuthActivity : BaseActivity<ActivitySyncAuthBinding>(), View.OnClickLi
 		viewBinding.buttonCancel.setOnClickListener(this)
 		viewBinding.buttonDone.setOnClickListener(this)
 		viewBinding.buttonSettings.setOnClickListener(this)
+		viewBinding.buttonForgotPassword.setOnClickListener(this)
 		viewBinding.editEmail.addTextChangedListener(this)
 		viewBinding.editPassword.addTextChangedListener(this)
 
 		onBackPressedDispatcher.addCallback(pageBackCallback)
 
 		viewModel.onTokenObtained.observeEvent(this, ::onTokenReceived)
+		viewModel.onPasswordReset.observeEvent(this, ::onPasswordReset)
 		viewModel.onError.observeEvent(this, ::onError)
 		viewModel.isLoading.observe(this, ::onLoadingStateChanged)
 		viewModel.onAccountAlreadyExists.observeEvent(this) {
@@ -123,6 +125,12 @@ class SyncAuthActivity : BaseActivity<ActivitySyncAuthBinding>(), View.OnClickLi
 			R.id.button_settings -> {
 				SyncHostDialogFragment.show(supportFragmentManager, viewModel.syncURL.value)
 			}
+
+			R.id.button_forgot_password -> {
+				viewModel.forgotPassword(
+					email = viewBinding.editEmail.text.toString().trim()
+				)
+			}
 		}
 	}
 
@@ -172,6 +180,7 @@ class SyncAuthActivity : BaseActivity<ActivitySyncAuthBinding>(), View.OnClickLi
 			buttonCancel.isVisible = page == PAGE_EMAIL
 			layoutEmail.isVisible = page == PAGE_EMAIL
 			layoutPassword.isVisible = page == PAGE_PASSWORD
+			buttonForgotPassword.isVisible = page == PAGE_PASSWORD
 		}
 		pageBackCallback.update()
 	}
@@ -201,6 +210,14 @@ class SyncAuthActivity : BaseActivity<ActivitySyncAuthBinding>(), View.OnClickLi
 		resultBundle = result
 		setResult(RESULT_OK)
 		finish()
+	}
+
+	private fun onPasswordReset(unit: Unit) {
+		MaterialAlertDialogBuilder(this)
+			.setNegativeButton(R.string.close, null)
+			.setTitle(R.string.forgot_password)
+			.setMessage("If a valid account exists, an email to reset your password has been sent to your inbox")
+			.show()
 	}
 
 	private fun onAccountAlreadyExists() {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthActivity.kt
@@ -216,7 +216,7 @@ class SyncAuthActivity : BaseActivity<ActivitySyncAuthBinding>(), View.OnClickLi
 		MaterialAlertDialogBuilder(this)
 			.setNegativeButton(R.string.close, null)
 			.setTitle(R.string.forgot_password)
-			.setMessage("If a valid account exists, an email to reset your password has been sent to your inbox")
+			.setMessage(getString(R.string.reset_email_sent))
 			.show()
 	}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthResetActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthResetActivity.kt
@@ -1,0 +1,136 @@
+package org.koitharu.kotatsu.sync.ui
+
+import android.content.Intent
+import android.os.Bundle
+import android.text.Editable
+import android.view.View
+import android.view.ViewGroup.MarginLayoutParams
+import android.widget.Toast
+import androidx.activity.viewModels
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.isInvisible
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
+import androidx.fragment.app.FragmentResultListener
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import dagger.hilt.android.AndroidEntryPoint
+import org.koitharu.kotatsu.R
+import org.koitharu.kotatsu.core.ui.BaseActivity
+import org.koitharu.kotatsu.core.ui.util.DefaultTextWatcher
+import org.koitharu.kotatsu.core.util.ext.consumeAllSystemBarsInsets
+import org.koitharu.kotatsu.core.util.ext.getDisplayMessage
+import org.koitharu.kotatsu.core.util.ext.observe
+import org.koitharu.kotatsu.core.util.ext.observeEvent
+import org.koitharu.kotatsu.core.util.ext.systemBarsInsets
+import org.koitharu.kotatsu.databinding.ActivitySyncAuthResetBinding
+import org.koitharu.kotatsu.settings.SettingsActivity
+
+private const val PASSWORD_MIN_LENGTH = 4
+
+@AndroidEntryPoint
+class SyncAuthResetActivity : BaseActivity<ActivitySyncAuthResetBinding>(), View.OnClickListener, FragmentResultListener,
+	DefaultTextWatcher {
+
+	private val viewModel by viewModels<SyncAuthResetViewModel>()
+
+	override fun onCreate(savedInstanceState: Bundle?) {
+		super.onCreate(savedInstanceState)
+		setContentView(ActivitySyncAuthResetBinding.inflate(layoutInflater))
+		viewBinding.buttonDone.setOnClickListener(this)
+		viewBinding.buttonCancel.setOnClickListener(this)
+		viewBinding.editPassword.addTextChangedListener(this)
+		viewBinding.editPasswordConfirm.addTextChangedListener(this)
+
+		viewModel.onPasswordResetSucceeded.observeEvent(this, ::onPasswordResetSucceeded)
+		viewModel.onError.observeEvent(this, ::onError)
+		viewModel.isLoading.observe(this, ::onLoadingStateChanged)
+
+		supportFragmentManager.setFragmentResultListener(SyncHostDialogFragment.REQUEST_KEY, this, this)
+
+		if(intent.action != Intent.ACTION_VIEW || intent.data?.host != SettingsActivity.HOST_RESET_PASSWORD) {
+			onNoTokenProvided()
+			return
+		}
+
+		val baseUrl = intent.data?.getQueryParameter("base_url")?.trim()
+		val token = intent.data?.getQueryParameter("token")?.trim()
+		if(token == null || token.isEmpty() || baseUrl == null || baseUrl.isEmpty()) {
+			onNoTokenProvided()
+			return
+		}
+
+		viewModel.syncURL.value = baseUrl
+		viewModel.resetToken.value = token
+	}
+
+	override fun onApplyWindowInsets(v: View, insets: WindowInsetsCompat): WindowInsetsCompat {
+		val barsInsets = insets.systemBarsInsets
+		viewBinding.root.updatePadding(top = barsInsets.top)
+		viewBinding.dockedToolbarChild.updateLayoutParams<MarginLayoutParams> {
+			leftMargin = barsInsets.left
+			rightMargin = barsInsets.right
+			bottomMargin = barsInsets.bottom
+		}
+		val basePadding = viewBinding.layoutContent.paddingBottom
+		viewBinding.layoutContent.updatePadding(
+			left = barsInsets.left + basePadding,
+			right = barsInsets.right + basePadding,
+		)
+		return insets.consumeAllSystemBarsInsets()
+	}
+
+	override fun onClick(v: View) {
+		when (v.id) {
+			R.id.button_cancel -> {
+				setResult(RESULT_CANCELED)
+				finish()
+			}
+
+			R.id.button_done -> {
+				viewModel.resetPassword(viewBinding.editPassword.text.toString())
+			}
+		}
+	}
+
+	override fun onFragmentResult(requestKey: String, result: Bundle) {
+		val syncURL = result.getString(SyncHostDialogFragment.KEY_SYNC_URL) ?: return
+		viewModel.syncURL.value = syncURL
+	}
+
+	override fun afterTextChanged(s: Editable?) {
+		val isLoading = viewModel.isLoading.value
+		val password = viewBinding.editPassword.text?.toString()
+		val passwordConfirm = viewBinding.editPasswordConfirm.text?.toString()
+		viewBinding.buttonDone.isEnabled = !isLoading && password != null && password.length >= PASSWORD_MIN_LENGTH && password == passwordConfirm
+	}
+
+	private fun onLoadingStateChanged(isLoading: Boolean) {
+		with(viewBinding) {
+			progressBar.isInvisible = !isLoading
+			editPassword.isEnabled = !isLoading
+			editPasswordConfirm.isEnabled = !isLoading
+		}
+		afterTextChanged(null)
+	}
+
+	private fun onError(error: Throwable) {
+		MaterialAlertDialogBuilder(this)
+			.setTitle(R.string.error)
+			.setMessage(error.getDisplayMessage(resources))
+			.setNegativeButton(R.string.close, null)
+			.show()
+	}
+
+	private fun onPasswordResetSucceeded(unit: Unit) {
+		Toast.makeText(this, getString(R.string.password_reset), Toast.LENGTH_SHORT)
+			.show()
+		setResult(RESULT_OK)
+		super.finishAfterTransition()
+	}
+
+	private fun onNoTokenProvided() {
+		Toast.makeText(this, "No reset token provided", Toast.LENGTH_SHORT)
+			.show()
+		super.finishAfterTransition()
+	}
+}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthResetActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthResetActivity.kt
@@ -128,7 +128,7 @@ class SyncAuthResetActivity : BaseActivity<ActivitySyncAuthResetBinding>(), View
 	}
 
 	private fun onNoTokenProvided() {
-		Toast.makeText(this, "No reset token provided", Toast.LENGTH_SHORT)
+		Toast.makeText(this, getString(R.string.no_reset_token), Toast.LENGTH_SHORT)
 			.show()
 		super.finishAfterTransition()
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthResetActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthResetActivity.kt
@@ -23,7 +23,6 @@ import org.koitharu.kotatsu.core.util.ext.observe
 import org.koitharu.kotatsu.core.util.ext.observeEvent
 import org.koitharu.kotatsu.core.util.ext.systemBarsInsets
 import org.koitharu.kotatsu.databinding.ActivitySyncAuthResetBinding
-import org.koitharu.kotatsu.settings.SettingsActivity
 
 private const val PASSWORD_MIN_LENGTH = 4
 
@@ -47,7 +46,7 @@ class SyncAuthResetActivity : BaseActivity<ActivitySyncAuthResetBinding>(), View
 
 		supportFragmentManager.setFragmentResultListener(SyncHostDialogFragment.REQUEST_KEY, this, this)
 
-		if(intent.action != Intent.ACTION_VIEW || intent.data?.host != SettingsActivity.HOST_RESET_PASSWORD) {
+		if(intent.action != Intent.ACTION_VIEW || intent.data?.host != HOST_RESET_PASSWORD) {
 			onNoTokenProvided()
 			return
 		}
@@ -132,5 +131,9 @@ class SyncAuthResetActivity : BaseActivity<ActivitySyncAuthResetBinding>(), View
 		Toast.makeText(this, "No reset token provided", Toast.LENGTH_SHORT)
 			.show()
 		super.finishAfterTransition()
+	}
+
+	companion object {
+		private const val HOST_RESET_PASSWORD = "reset-password"
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthResetViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthResetViewModel.kt
@@ -1,0 +1,34 @@
+package org.koitharu.kotatsu.sync.ui
+
+import android.content.Context
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.koitharu.kotatsu.R
+import org.koitharu.kotatsu.core.ui.BaseViewModel
+import org.koitharu.kotatsu.core.util.ext.MutableEventFlow
+import org.koitharu.kotatsu.core.util.ext.call
+import org.koitharu.kotatsu.sync.data.SyncAuthApi
+import javax.inject.Inject
+
+@HiltViewModel
+class SyncAuthResetViewModel @Inject constructor(
+	@ApplicationContext context: Context,
+	private val api: SyncAuthApi,
+) : BaseViewModel() {
+
+	val onPasswordResetSucceeded = MutableEventFlow<Unit>()
+	val syncURL = MutableStateFlow(context.resources.getStringArray(R.array.sync_url_list).first())
+	val resetToken = MutableStateFlow<String?>(null)
+
+	fun resetPassword(password: String) {
+		val urlValue = syncURL.value
+		val resetTokenValue = resetToken.value ?: return // Token should never be null because the fragment exits if none is provided
+
+		launchLoadingJob(Dispatchers.Default) {
+			api.resetPassword(urlValue, resetTokenValue, password)
+			onPasswordResetSucceeded.call(Unit)
+		}
+	}
+}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/sync/ui/SyncAuthViewModel.kt
@@ -22,6 +22,7 @@ class SyncAuthViewModel @Inject constructor(
 
 	val onAccountAlreadyExists = MutableEventFlow<Unit>()
 	val onTokenObtained = MutableEventFlow<SyncAuthResult>()
+	val onPasswordReset = MutableEventFlow<Unit>()
 	val syncURL = MutableStateFlow(context.resources.getStringArray(R.array.sync_url_list).first())
 
 	init {
@@ -40,6 +41,14 @@ class SyncAuthViewModel @Inject constructor(
 			val token = api.authenticate(urlValue, email, password)
 			val result = SyncAuthResult(syncURL.value, email, password, token)
 			onTokenObtained.call(result)
+		}
+	}
+
+	fun forgotPassword(email: String) {
+		val urlValue = syncURL.value
+		launchLoadingJob(Dispatchers.Default) {
+			api.forgotPassword(urlValue, email)
+			onPasswordReset.call(Unit)
 		}
 	}
 }

--- a/app/src/main/res/layout/activity_sync_auth.xml
+++ b/app/src/main/res/layout/activity_sync_auth.xml
@@ -93,13 +93,26 @@
 
 			</com.google.android.material.textfield.TextInputLayout>
 
-			<Button
-				android:id="@+id/button_settings"
-				style="?borderlessButtonStyle"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
+			<LinearLayout
+				android:layout_width="match_parent"
+				android:layout_height="match_parent"
 				android:layout_marginTop="4dp"
-				android:text="@string/settings" />
+				android:orientation="horizontal">
+
+				<Button
+					android:id="@+id/button_settings"
+					style="?borderlessButtonStyle"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:text="@string/settings" />
+
+				<Button
+					android:id="@+id/button_forgot_password"
+					style="?borderlessButtonStyle"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:text="@string/forgot_password" />
+			</LinearLayout>
 
 		</LinearLayout>
 

--- a/app/src/main/res/layout/activity_sync_auth_reset.xml
+++ b/app/src/main/res/layout/activity_sync_auth_reset.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:orientation="vertical">
+
+	<TextView
+		android:id="@+id/textView_title"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_marginHorizontal="@dimen/screen_padding"
+		android:layout_marginTop="24dp"
+		android:drawablePadding="@dimen/screen_padding"
+		android:gravity="center_horizontal"
+		android:text="@string/sync_auth_reset_title"
+		android:textAppearance="?textAppearanceHeadline5"
+		app:drawableTint="?colorPrimary"
+		app:drawableTopCompat="@drawable/ic_sync" />
+
+	<com.google.android.material.progressindicator.LinearProgressIndicator
+		android:id="@+id/progressBar"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_marginHorizontal="@dimen/screen_padding"
+		android:layout_marginTop="@dimen/screen_padding"
+		android:max="100"
+		android:visibility="invisible" />
+
+	<ScrollView
+		android:id="@+id/scrollView"
+		android:layout_width="match_parent"
+		android:layout_height="0dp"
+		android:layout_weight="1">
+
+		<LinearLayout
+			android:id="@+id/layout_content"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:orientation="vertical"
+			android:paddingHorizontal="@dimen/screen_padding"
+			android:paddingBottom="@dimen/screen_padding">
+
+			<TextView
+				android:id="@+id/textView_subtitle"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:text="@string/sync_auth_reset_hint"
+				android:textAppearance="?textAppearanceBodySmall" />
+
+			<com.google.android.material.textfield.TextInputLayout
+				android:id="@+id/layout_password"
+				style="?textInputOutlinedStyle"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginTop="30dp"
+				app:endIconMode="password_toggle"
+				app:errorIconDrawable="@null">
+
+				<com.google.android.material.textfield.TextInputEditText
+					android:id="@+id/edit_password"
+					android:layout_width="match_parent"
+					android:layout_height="wrap_content"
+					android:autofillHints="password"
+					android:hint="@string/password"
+					android:imeOptions="actionDone"
+					android:inputType="textPassword"
+					android:maxLength="24"
+					android:singleLine="true"
+					android:textSize="16sp" />
+
+			</com.google.android.material.textfield.TextInputLayout>
+
+			<com.google.android.material.textfield.TextInputLayout
+				android:id="@+id/layout_password_confirm"
+				style="?textInputOutlinedStyle"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_marginTop="30dp"
+				app:endIconMode="password_toggle"
+				app:errorIconDrawable="@null">
+
+				<com.google.android.material.textfield.TextInputEditText
+					android:id="@+id/edit_password_confirm"
+					android:layout_width="match_parent"
+					android:layout_height="wrap_content"
+					android:autofillHints="password"
+					android:hint="@string/confirm_password"
+					android:imeOptions="actionDone"
+					android:inputType="textPassword"
+					android:maxLength="24"
+					android:singleLine="true"
+					android:textSize="16sp" />
+
+			</com.google.android.material.textfield.TextInputLayout>
+
+		</LinearLayout>
+
+	</ScrollView>
+
+	<com.google.android.material.dockedtoolbar.DockedToolbarLayout
+		android:id="@+id/docked_toolbar"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:fitsSystemWindows="false">
+
+		<FrameLayout
+			android:id="@+id/docked_toolbar_child"
+			android:layout_width="match_parent"
+			android:layout_height="@dimen/m3_comp_toolbar_docked_container_height">
+
+			<Button
+				android:id="@+id/button_cancel"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_gravity="center_vertical|start"
+				android:text="@android:string/cancel" />
+
+			<Button
+				android:id="@+id/button_done"
+				style="?materialButtonTonalStyle"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_gravity="center_vertical|end"
+				android:enabled="false"
+				android:text="@string/done" />
+
+		</FrameLayout>
+	</com.google.android.material.dockedtoolbar.DockedToolbarLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -654,9 +654,9 @@
     <string name="reader_navigation_inverted">Steuerung umkehren</string>
     <string name="minutes_seconds_short">%1$d m %2$d s</string>
     <string name="forgot_password">Passwort vergessen</string>
-	<string name="reset_email_sent">Falls das Konto existiert, wurde eine E-Mail zum Zurücksetzen des Passworts versendet.</string>
+	<string name="reset_email_sent">Falls der Account existiert, wurde eine E-Mail zum Zurücksetzen des Passworts versendet.</string>
 	<string name="sync_auth_reset_title">Passwort zurücksetzen</string>
-	<string name="sync_auth_reset_hint">Bitte lege ein neues Passwort für dein Konto fest</string>
+	<string name="sync_auth_reset_hint">Bitte lege ein neues Passwort für deinen Account fest</string>
 	<string name="confirm_password">Passwort bestätigen</string>
 	<string name="password_reset">Passwort erfolgreich zurückgesetzt</string>
 	<string name="sync_login">Melde dich an, um deine Daten zu synchronisieren</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -660,4 +660,5 @@
 	<string name="confirm_password">Passwort bestätigen</string>
 	<string name="password_reset">Passwort erfolgreich zurückgesetzt</string>
 	<string name="sync_login">Melde dich an, um deine Daten zu synchronisieren</string>
+	<string name="no_reset_token">Reset-Token wurde nicht übergeben</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -653,4 +653,11 @@
     <string name="plugin_incompatible">Inkompatibles Plugin oder Interner Fehler. Stelle sicher, dass du die letzte Version von Kotatsu und die des Plugins verwendest</string>
     <string name="reader_navigation_inverted">Steuerung umkehren</string>
     <string name="minutes_seconds_short">%1$d m %2$d s</string>
+    <string name="forgot_password">Passwort vergessen</string>
+	<string name="reset_email_sent">Falls das Konto existiert, wurde eine E-Mail zum Zurücksetzen des Passworts versendet.</string>
+	<string name="sync_auth_reset_title">Passwort zurücksetzen</string>
+	<string name="sync_auth_reset_hint">Bitte lege ein neues Passwort für dein Konto fest</string>
+	<string name="confirm_password">Passwort bestätigen</string>
+	<string name="password_reset">Passwort erfolgreich zurückgesetzt</string>
+	<string name="sync_login">Melde dich an, um deine Daten zu synchronisieren</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -909,4 +909,8 @@
     <string name="available_pattern">%1$s available</string>
 	<string name="forgot_password">Forgot password</string>
 	<string name="reset_email_sent">If a valid account exists, an email to reset your password has been sent to your inbox</string>
+    <string name="sync_auth_reset_title">Reset password</string>
+	<string name="sync_auth_reset_hint">Please set a new password for your account</string>
+	<string name="confirm_password">Confirm Password</string>
+	<string name="password_reset">Password reset successfully</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -913,4 +913,5 @@
 	<string name="sync_auth_reset_hint">Please set a new password for your account</string>
 	<string name="confirm_password">Confirm Password</string>
 	<string name="password_reset">Password reset successfully</string>
+	<string name="no_reset_token">No reset token provided</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,6 +242,7 @@
     <string name="sync">Synchronization</string>
     <string name="sync_title">Sync your data</string>
     <string name="sync_login">Log in to sync your data</string>
+	<string name="reset_password">Reset password</string>
     <string name="email_enter_hint">Enter your email to continue</string>
     <string name="hide">Hide</string>
     <string name="new_sources_text">New manga sources are available</string>
@@ -906,4 +907,5 @@
     <string name="download_default_directory">Default directory for downloading manga</string>
     <string name="private_app_directory_warning">This directory with all data will be deleted if you uninstall the application</string>
     <string name="available_pattern">%1$s available</string>
+	<string name="forgot_password">Forgot password</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,6 +241,7 @@
     <string name="back">Back</string>
     <string name="sync">Synchronization</string>
     <string name="sync_title">Sync your data</string>
+    <string name="sync_login">Log in to sync your data</string>
     <string name="email_enter_hint">Enter your email to continue</string>
     <string name="hide">Hide</string>
     <string name="new_sources_text">New manga sources are available</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -908,4 +908,5 @@
     <string name="private_app_directory_warning">This directory with all data will be deleted if you uninstall the application</string>
     <string name="available_pattern">%1$s available</string>
 	<string name="forgot_password">Forgot password</string>
+	<string name="reset_email_sent">If a valid account exists, an email to reset your password has been sent to your inbox</string>
 </resources>

--- a/app/src/main/res/xml/pref_services.xml
+++ b/app/src/main/res/xml/pref_services.xml
@@ -4,18 +4,10 @@
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	android:title="@string/services">
 
-	<Preference
-		android:enabled="@bool/is_sync_enabled"
-		android:key="sync"
-		android:persistent="false"
-		android:summary="@string/sync_title"
-		android:title="@string/sync" />
-
 	<PreferenceScreen
-		android:enabled="false"
 		android:fragment="org.koitharu.kotatsu.settings.SyncSettingsFragment"
 		android:key="sync_settings"
-		android:title="@string/sync_settings" />
+		android:title="@string/sync" />
 
 	<PreferenceScreen
 		android:fragment="org.koitharu.kotatsu.settings.SuggestionsSettingsFragment"

--- a/app/src/main/res/xml/pref_sync.xml
+++ b/app/src/main/res/xml/pref_sync.xml
@@ -3,7 +3,20 @@
 	xmlns:android="http://schemas.android.com/apk/res/android">
 
 	<Preference
+		android:enabled="@bool/is_sync_enabled"
+		android:key="sync"
+		android:persistent="false"
+		android:summary="@string/sync_title"
+		android:title="@string/sync" />
+
+	<Preference
+		android:enabled="false"
 		android:key="host"
 		android:title="@string/server_address" />
+
+	<Preference
+		android:enabled="false"
+		android:key="logout"
+		android:title="@string/logout" />
 
 </PreferenceScreen>


### PR DESCRIPTION
This reworks the sync settings by moving them all into a separate submenu (instead of just having the server URL in the sync settings) and adding an additional option to log out of the account without having to go to the phone settings.

Also adds a button to the sync login page to request a password reset and a new activity to handle password reset links from the reset emails.

Since there are some new strings, I added German translations for them, but I don't know how translation submission is handled in this project for users to add translations for the other languages.

Note: This requires an additional change in [kotatsu-syncserver#2](https://github.com/Kotatsu-Redo/kotatsu-syncserver/pull/2) to provide the sync server base URL in the reset links, so the user doesn't have to manually select it again after clicking a password reset link.