### PR TITLE
chore: enhance Discord webhook workflows

### DIFF
--- a/.github/workflows/new-commit-discord.yml
+++ b/.github/workflows/new-commit-discord.yml
@@ -9,13 +9,27 @@ jobs:
   discordNotification:
     runs-on: ubuntu-latest
     steps:
+      - name: Build commit description
+        id: build
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          MSG="${COMMIT_MSG:-No commit message.}"
+          if [ ${#MSG} -gt 1000 ]; then
+            MSG="${MSG:0:1000}..."
+          fi
+          {
+            echo "description<<EOF"
+            echo "$MSG"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Send commit embed to Discord
         uses: tsickert/discord-webhook@v7.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           embed-title: "New Commit: ${{ github.event.repository.name }}"
           embed-url: "${{ github.event.head_commit.url }}"
-          embed-description: "${{ github.event.head_commit.message }}"
+          embed-description: ${{ steps.build.outputs.description }}
           embed-color: 5814783
           embed-author-name: "${{ github.actor }}"
           embed-author-icon-url: "https://github.com/${{ github.actor }}.png"

--- a/.github/workflows/new-issue-discord.yml
+++ b/.github/workflows/new-issue-discord.yml
@@ -8,13 +8,27 @@ jobs:
   discordNotification:
     runs-on: ubuntu-latest
     steps:
+      - name: Build issue description
+        id: build
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          BODY="${ISSUE_BODY:-No description provided.}"
+          if [ ${#BODY} -gt 1000 ]; then
+            BODY="${BODY:0:1000}..."
+          fi
+          {
+            echo "description<<EOF"
+            echo "$BODY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Send issue embed to Discord
         uses: tsickert/discord-webhook@v7.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           embed-title: "New Issue: ${{ github.event.issue.title }}"
           embed-url: "${{ github.event.issue.html_url }}"
-          embed-description: "${{ github.event.issue.body }}"
+          embed-description: ${{ steps.build.outputs.description }}
           embed-color: 5814783
           embed-author-name: "${{ github.event.issue.user.login }}"
           embed-author-icon-url: "${{ github.event.issue.user.avatar_url }}"

--- a/.github/workflows/new-release-discord.yml
+++ b/.github/workflows/new-release-discord.yml
@@ -10,6 +10,24 @@ jobs:
     name: Notify Discord - New Release
     runs-on: ubuntu-latest
     steps:
+      - name: Build description with assets
+        id: build
+        env:
+          RELEASE_BODY: ${{ github.event.release.body }}
+          ASSETS_JSON: ${{ toJSON(github.event.release.assets) }}
+        run: |
+          BODY="${RELEASE_BODY:-No release notes provided.}"
+          BODY=$(printf '%s' "$BODY" | awk '{lines[NR]=$0} END{while(NR>0 && lines[NR]~/^[[:space:]]*$/) NR--; for(i=1;i<=NR;i++) print lines[i]}')
+          ASSETS=$(echo "$ASSETS_JSON" | jq -r '.[] | "- [\(.name)](\(.browser_download_url))"')
+          DESC="${BODY}"$'\n\n'"> ℹ️ This app supports in-app updates - Open Settings and tap **Check for updates** instead of downloading manually."
+          if [ -n "$ASSETS" ]; then
+            DESC="${DESC}"$'\n\n'"**Downloads**"$'\n'"${ASSETS}"
+          fi
+          {
+            echo "description<<EOF"
+            echo "$DESC"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Send release embed to Discord
         uses: tsickert/discord-webhook@v7.0.0
         with:
@@ -17,7 +35,7 @@ jobs:
           content: "<@&1435675462759088168>"
           embed-title: "🚀 New Release: ${{ github.event.repository.name }} v${{ github.event.release.tag_name }}"
           embed-url: "${{ github.event.release.html_url }}"
-          embed-description: "${{ github.event.release.body }}"
+          embed-description: ${{ steps.build.outputs.description }}
           embed-color: 3447003
           embed-author-name: "${{ github.actor }}"
           embed-author-icon-url: "https://github.com/${{ github.actor }}.png"
@@ -29,13 +47,31 @@ jobs:
     name: Notify Discord - Pre-Release
     runs-on: ubuntu-latest
     steps:
+      - name: Build description with assets
+        id: build
+        env:
+          RELEASE_BODY: ${{ github.event.release.body }}
+          ASSETS_JSON: ${{ toJSON(github.event.release.assets) }}
+        run: |
+          BODY="${RELEASE_BODY:-No release notes provided.}"
+          BODY=$(printf '%s' "$BODY" | awk '{lines[NR]=$0} END{while(NR>0 && lines[NR]~/^[[:space:]]*$/) NR--; for(i=1;i<=NR;i++) print lines[i]}')
+          ASSETS=$(echo "$ASSETS_JSON" | jq -r '.[] | "- [\(.name)](\(.browser_download_url))"')
+          DESC="${BODY}"$'\n\n'"> ℹ️ This app supports in-app updates for pre-releases - Open Settings and tap **Check for updates** instead of downloading manually."
+          if [ -n "$ASSETS" ]; then
+            DESC="${DESC}"$'\n\n'"**Downloads**"$'\n'"${ASSETS}"
+          fi
+          {
+            echo "description<<EOF"
+            echo "$DESC"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       - name: Send prerelease embed to Discord
         uses: tsickert/discord-webhook@v7.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
-          embed-title: "🧪 Pre-Release: ${{ github.event.repository.name }} ${{ github.event.release.tag_name }}"
+          embed-title: "🧪 Pre-Release: ${{ github.event.repository.name }} v${{ github.event.release.tag_name }}"
           embed-url: "${{ github.event.release.html_url }}"
-          embed-description: "${{ github.event.release.body }}"
+          embed-description: ${{ steps.build.outputs.description }}
           embed-color: 15105570
           embed-author-name: "${{ github.actor }}"
           embed-author-icon-url: "https://github.com/${{ github.actor }}.png"


### PR DESCRIPTION
Enhances all three Discord notification workflows:

**Release webhook**
- Asset download links are now listed under a **Downloads** section in both release and pre-release embeds
- Trailing blank lines in the release body are stripped before sending
- A notice is appended to both release types reminding users that in-app updates are supported for pre-releases
- Fixed missing `v` prefix in the pre-release embed title

**Commit webhook**
- Commit message is now built in a dedicated step with a null fallback and 1000-character truncation to avoid oversized embeds

**Issue webhook**
- Issue body is now built in a dedicated step with a null fallback and 1000-character truncation to avoid oversized embeds